### PR TITLE
Refactor profileInfoEdit to team based profile management

### DIFF
--- a/client/src/components/profileInfoEdit/ProfileInfoEdit.css
+++ b/client/src/components/profileInfoEdit/ProfileInfoEdit.css
@@ -22,7 +22,7 @@
     border-radius: 5px;
     background-color: #f2f2f2;
     padding: 20px;
-    border-style: solid;
+    box-shadow: 0px 0px 15px -5px black;
   }
 
 .profile-title-name {

--- a/client/src/components/profileInfoEdit/ProfileInfoEdit.js
+++ b/client/src/components/profileInfoEdit/ProfileInfoEdit.js
@@ -5,7 +5,7 @@
 
 import React from "react";
 
-import { Button, Form, Row, Col, Container, Image} from 'react-bootstrap';
+import { Button, Form, Row, Col, Container, Image, InputGroup} from 'react-bootstrap';
 import './ProfileInfoEdit.css';
 import profilePic from '../../images/profilepic.jpg';
 import {Link} from 'react-router-dom';
@@ -13,10 +13,10 @@ import {Link} from 'react-router-dom';
 function ProfileInfoEdit () {
 
         return (
-            <div >
+            <div className='mt-5' >
                 <Container className = "profile-container">
                     <Form className = "profile-form">
-                        <p className = "profile-title-name">Edit Profile</p>
+                        <p className = "profile-title-name">Team Profile Management</p>
 
                         <Form.Group controlId="formProfilePic">
                             <Image src={profilePic} roundedCircle height="184px" width="184px" />
@@ -26,21 +26,10 @@ function ProfileInfoEdit () {
                             </Form.Text>
                         </Form.Group>
 
-                        <Row>
-                            <Col>
-                                <Form.Group controlId="formUserFirstName">
-                                    <Form.Label>First Name</Form.Label>
-                                    <Form.Control type="text" placeholder="John" />
-                                </Form.Group>
-                            </Col>
-                            
-                            <Col>
-                                <Form.Group controlId="formUserLastName">
-                                    <Form.Label>Last Name</Form.Label>
-                                    <Form.Control type="text" placeholder="Doe" />
-                                </Form.Group>
-                            </Col>
-                        </Row>
+                        <Form.Group controlId="formUserFirstName">
+                            <Form.Label>Research Group Name</Form.Label>
+                            <Form.Control type="text" placeholder="Team name.." />
+                        </Form.Group>
 
                         <Form.Group controlId="formCountry">
                                     <Form.Label>Country</Form.Label>
@@ -61,25 +50,57 @@ function ProfileInfoEdit () {
                              <Form.Control type="text" placeholder="+62123456789" />
                         </Form.Group>
 
+                        <Form.Group controlId="formWebUrl">
+                             <Form.Label>Website URL</Form.Label>
+                             <InputGroup className="mb-3">
+                                <Form.Control 
+                                    type="text"
+                                    placeholder="Team custom URL"
+                                    aria-label="Team custom URL"
+                                    aria-describedby="basic-addon2"
+                                />
+                                <InputGroup.Append>
+                                    <InputGroup.Text id="basic-addon2">researchify.com</InputGroup.Text>
+                                </InputGroup.Append>
+                             </InputGroup>
+                        </Form.Group>
+
+                        <div className= "my-1">
+                            <Button 
+                                color="primary"
+                                className= "mr-2"
+                                onClick={(event) => {
+                                    event.preventDefault();
+                                    alert('You have updated your profile')
+                                    /**
+                                     * Update user information here onclick button
+                                     */
+                                }}
+                            >
+                                Update
+                            </Button>
+                            
+                            {/* Button is linked to react-router-dom Link*/}
+                            <Link to='/dashboard'>
+                                <Button color="primary">
+                                    Back
+                                </Button>
+                            </Link>
+                        </div>
+                        <div className="my-1">
                         <Button 
-                            color="primary"
+                            variant="danger"
                             onClick={(event) => {
                                 event.preventDefault();
-                                alert('You have updated your profile')
+                                alert('Your account has been deleted')
                                 /**
                                  * Update user information here onclick button
                                  */
                             }}
                         >
-                            Update
-                        </Button>{' '}
-                        
-                        {/* Button is linked to react-router-dom Link*/}
-                        <Link to='/dashboard'>
-                            <Button color="primary">
-                                Back
-                            </Button>
-                        </Link>
+                            Delete account
+                        </Button>
+                        </div>
 
                     </Form>
                 </Container>


### PR DESCRIPTION
# Description 
Current profile management is for single user, this update changes the input fields to team based. Changed form border for consistency with login/register page, option to edit custom url, and added a button for deleting team account


# Type of change 
- [ ] Bug fix
- [ ] New feature
- [X] Refactoring
- [ ] Documentation 


# Problem
Client requirement has made it that one research group will be represented by one account.


# Solution description
Changed profile management to team based rather than single user based.


# Tests 
All unit tests pass? Y
Build successfully? Y <br/>
Attach screenshot of the expected result (e.g. UI of the website/ postman api call result/ database changes) <br/>
![image](https://user-images.githubusercontent.com/53892953/116842116-ad76f380-ac05-11eb-9bf2-650b8d5c197b.png)

Provide steps in detail for reviewers to reproduce the expected result of the code changes <br/>
N/A

# Relevant document/ link (if any) 
N/A


# Risk
Low risk
