### PR TITLE
Aksh0001/experimental

### DIFF
--- a/api/src/models/editor/template.model.js
+++ b/api/src/models/editor/template.model.js
@@ -1,0 +1,20 @@
+/**
+ * This module exports a "Template" mongoose Schema, which represents a predefined set of templates for their site.
+ */
+const mongoose = require('mongoose');
+
+const templateSchema = new mongoose.Schema({
+    isDefault: {
+        type: Boolean,
+        required: true
+    },
+    themeId: {
+        type: mongoose.SchemaTypes.ObjectId,
+        ref: 'theme',
+        required: true
+    }
+}, {timestamps: true})
+
+const Template = mongoose.model('template', templateSchema);
+
+module.exports = Template;

--- a/api/src/models/editor/theme.model.js
+++ b/api/src/models/editor/theme.model.js
@@ -1,0 +1,29 @@
+/**
+ * This module exports a "Theme" mongoose Schema, which represents a predefined set of theme preferences for their site.
+ */
+const mongoose = require('mongoose');
+
+const themeSchema = new mongoose.Schema({
+    primaryColor: {
+        type: String,
+        required: true,
+        minlength: 4,  // e.g. #09C
+        maxlength: 7,  // e.g. #0099CC
+        uppercase: true,
+        trim: true,
+        match: /^#([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/
+    },
+    secondaryColor: {
+        type: String,
+        required: true,
+        minlength: 4,
+        maxlength: 7,
+        uppercase: true,
+        trim: true,
+        match: /^#([a-fA-F0-9]{3}|[a-fA-F0-9]{6})$/
+    }
+}, {timestamps: true})
+
+const Theme = mongoose.model('theme', themeSchema);
+
+module.exports = Theme;

--- a/api/src/models/publication.model.js
+++ b/api/src/models/publication.model.js
@@ -6,7 +6,7 @@ const mongoose = require('mongoose');
 const publicationSchema = new mongoose.Schema({
     teamId: {
         type: mongoose.SchemaTypes.ObjectId,
-        ref: 'Team',
+        ref: 'team',
         required: true
     },
     authors: {
@@ -42,6 +42,10 @@ const publicationSchema = new mongoose.Schema({
     },
     yearPublished: {
         type: Date
+    },
+    templateId: {
+        type: mongoose.SchemaTypes.ObjectId,
+        ref: 'template'
     }
 }, {timestamps: true})
 

--- a/api/src/models/publication.model.js
+++ b/api/src/models/publication.model.js
@@ -43,10 +43,6 @@ const publicationSchema = new mongoose.Schema({
     yearPublished: {
         type: Date
     },
-    templateId: {
-        type: mongoose.SchemaTypes.ObjectId,
-        ref: 'template'
-    }
 }, {timestamps: true})
 
 const Publication = mongoose.model('publication', publicationSchema);

--- a/api/src/models/team.model.js
+++ b/api/src/models/team.model.js
@@ -1,29 +1,34 @@
 /**
  * This module exports a "Team" mongoose Schema, which represents a researcher team.
  */
- const mongoose = require('mongoose');
+const mongoose = require('mongoose');
 
- 
- const teamSchema = new mongoose.Schema({
-     teamName: {
-         type: String,
-         required: true
-     },
-     dateCreated: {
-         type: Date,
-         required: true
-     },
-     areaOfInterest: {
+
+const teamSchema = new mongoose.Schema({
+    teamName: {
+        type: String,
+        required: true
+    },
+    dateCreated: {
+        type: Date,
+        required: true
+    },
+    areaOfInterest: {
         type: [{
             type: String,
             minlength: 1
         }]
     },
-     twitterHandle: {
+    twitterHandle: {
         type: String
+    },
+    templateId: {
+        type: mongoose.SchemaTypes.ObjectId,
+        ref: 'template',
+        required: true
     }
- }, {timestamps: true})
- 
- const Team = mongoose.model('team', teamSchema);
- 
- module.exports = Team;
+}, {timestamps: true})
+
+const Team = mongoose.model('team', teamSchema);
+
+module.exports = Team;

--- a/api/src/seederScript.js
+++ b/api/src/seederScript.js
@@ -6,6 +6,9 @@ require('dotenv').config()
 const connectDb = require('./config/db');
 const Publication = require('./models/publication.model');
 const User = require('./models/user.model');
+const Team = require('./models/team.model');
+const Template = require('./models/editor/template.model');
+const Theme = require('./models/editor/theme.model');
 
 
 connectDb();
@@ -60,7 +63,47 @@ const defaultUsers = [
     },
 ];
 
-const importData = async () => {
+const defaultThemes = [
+    {
+        "primaryColor": "#4DD0E1",
+        "secondaryColor": "#FFFFFF"
+    },
+    {
+        "primaryColor": "#FF5733",
+        "secondaryColor": "#FFFFFF"
+    }
+];
+
+const defaultTemplates = [
+    {
+        "isDefault": true,
+        "themeId": "609f593f4edeaf8147dc537d"  // retrieved id after populating themes
+    },
+    {
+        "isDefault": false,
+        "themeId": "609f593f4edeaf8147dc537e"
+    }
+]
+
+const defaultTeams = [
+    {
+        "teamName": "TestTeam1",
+        "dateCreated": Date.now(),
+        "templateId": "609f5a397c35738204fded7a"  // retrieved id after populating templates
+    },
+    {
+        "teamName": "TestTeam2",
+        "dateCreated": Date.now(),
+        "templateId": "609f5a397c35738204fded7a"
+    },
+    {
+        "teamName": "TestTeam3",
+        "dateCreated": Date.now(),
+        "templateId": "609f5a397c35738204fded7b"
+    }
+];
+
+const populatePublications = async () => {
     try {
         await Publication.deleteMany({});
 
@@ -86,5 +129,47 @@ const populateUsers = async () => {
     }
 };
 
-importData();
-populateUsers();
+const populateThemes = async () => {
+    try {
+        await Theme.deleteMany({});
+
+        await Theme.insertMany(defaultThemes);
+        console.log('Successfully imported themes.')
+        process.exit(0);
+    } catch (err) {
+        console.error('Error importing themes.');
+        process.exit(1);
+    }
+}
+
+const populateTemplates = async () => {
+    try {
+        await Template.deleteMany({});
+
+        await Template.insertMany(defaultTemplates);
+        console.log('Successfully imported templates.')
+        process.exit(0);
+    } catch (err) {
+        console.error('Error importing templates.');
+        process.exit(1);
+    }
+}
+
+const populateTeams = async () => {
+    try {
+        // await Team.deleteMany({}); // frontend code relies on one of the default teams, don't remove it
+
+        await Team.insertMany(defaultTeams);
+        console.log('Successfully imported teams.')
+        process.exit(0);
+    } catch (err) {
+        console.error('Error importing teams.');
+        process.exit(1);
+    }
+}
+
+// populatePublications();
+// populateUsers();
+// populateThemes();
+// populateTemplates();
+populateTeams();

--- a/api/src/seederScript.js
+++ b/api/src/seederScript.js
@@ -168,8 +168,8 @@ const populateTeams = async () => {
     }
 }
 
-// populatePublications();
-// populateUsers();
-// populateThemes();
-// populateTemplates();
+populatePublications();
+populateUsers();
+populateThemes();
+populateTemplates();
 populateTeams();


### PR DESCRIPTION
# Description 
Currently, there is no way to save user preferences for a website: such as layout, themes, color preferences etc. I created models to implement this as other frontend developers will need to make use of this information to decide on the colors, themes, visuals, etc. for their components to maintain consistency.


# Type of change 
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation 


# Problem
No way to associate user website preferences, so added models to do that.


# Solution description
Added models for `template` and `theme`, and modified `team` model to take this into account.


# Tests 
All unit tests pass? Y

Builds successfully? Y

Run `seederScript.js` in api/src directory to see results.

Theme:
![Screenshot from 2021-05-15 00-25-49](https://user-images.githubusercontent.com/38117036/118349114-609ff080-b514-11eb-9f63-720f111022c2.png)

Template:
![Screenshot from 2021-05-15 00-25-58](https://user-images.githubusercontent.com/38117036/118349115-6269b400-b514-11eb-8576-13721b5202e6.png)

Team:
![Screenshot from 2021-05-15 00-26-08](https://user-images.githubusercontent.com/38117036/118349116-64337780-b514-11eb-86ac-c7fbb5e86cba.png)



# Relevant document/ link (if any) 
https://docs.google.com/document/d/1U68bJV0POrh_wDXem_hZ_PrivoVT6qZCPC8vw7Dg5uQ/edit#


# Risk
Low, additive.
