### PR TITLE
Add API Request to update team details 

### DIFF
--- a/api/src/controllers/team.js
+++ b/api/src/controllers/team.js
@@ -4,7 +4,6 @@
 const axios = require("axios");
 const mongoose = require("mongoose");
 const Team = require("../models/team.model");
-const teamRouter = require("../routes/team");
 
 
 const options = {

--- a/api/src/controllers/team.js
+++ b/api/src/controllers/team.js
@@ -2,6 +2,9 @@
  * This module contains handlers for the "team" route.
  */
 const axios = require("axios");
+const mongoose = require("mongoose");
+const Team = require("../models/team.model");
+const teamRouter = require("../routes/team");
 
 
 const options = {
@@ -59,4 +62,21 @@ async function getTeam(req, res) {
 
 }
 
-module.exports = { storeHandle, getTeam };
+async function updateTeam(req, res) {
+    const { id: _id } = req.params;
+    const updates = req.body;
+    const options = {new: true};
+
+    if (!mongoose.Types.ObjectId.isValid(_id))
+    return res.status(404).send("Error: No team with that id.");
+
+    try {
+        const result = await Team.findByIdAndUpdate(_id, updates, options);
+        // res.send(result);
+        res.status(200).json(result);
+    } catch (err) {
+        res.status(400).json(`Error: ${err.message}`);
+    }
+}
+
+module.exports = { storeHandle, getTeam, updateTeam };

--- a/api/src/controllers/team.js
+++ b/api/src/controllers/team.js
@@ -61,6 +61,14 @@ async function getTeam(req, res) {
 
 }
 
+/**
+ * Handles a PATCH request to update a team's details on the endpoint /team/:id.
+ * @param {*} req request object - team id in url, json object containing atleast one field from team model.
+ * @param {*} res response object - updated team object
+ * @returns 200: returns updated team details
+ * @returns 404: team not found
+ * @returns 400: error updating team
+ */
 async function updateTeam(req, res) {
     const { id: _id } = req.params;
     const updates = req.body;
@@ -71,7 +79,6 @@ async function updateTeam(req, res) {
 
     try {
         const result = await Team.findByIdAndUpdate(_id, updates, options);
-        // res.send(result);
         res.status(200).json(result);
     } catch (err) {
         res.status(400).json(`Error: ${err.message}`);

--- a/api/src/models/team.model.js
+++ b/api/src/models/team.model.js
@@ -21,6 +21,9 @@
     },
      twitterHandle: {
         type: String
+    },
+    github_token: {
+        type: String
     }
  }, {timestamps: true})
  

--- a/api/src/models/team.model.js
+++ b/api/src/models/team.model.js
@@ -22,7 +22,7 @@
      twitterHandle: {
         type: String
     },
-    github_token: {
+     githubToken: {
         type: String
     }
  }, {timestamps: true})

--- a/api/src/routes/team.js
+++ b/api/src/routes/team.js
@@ -1,5 +1,5 @@
 /**
- * This module defines the endpoints for the "/twitter" route and exports the corresponding Router.
+ * This module defines the endpoints for the "/team" route and exports the corresponding Router.
  */
 
 const teamRouter = require("express").Router();
@@ -11,5 +11,7 @@ const teamMiddleware = require('../middleware/team');
 teamRouter.patch('/:team_id/twitter-handle', teamMiddleware.validateTeamId, teamMiddleware.validateTwitterHandle, teamController.storeHandle);
 
 teamRouter.get('/:team_id', teamMiddleware.validateTeamId, teamController.getTeam);
+
+teamRouter.patch('/:id',teamController.updateTeam);
 
 module.exports = teamRouter;


### PR DESCRIPTION
# Description 
Added a `PATCH` api request to allow updating a team's details.


# Type of change 
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation 


# Problem
Needed a way to add/update information on the `Team` model (i.e. need to be able to add GitHub Token to team's model at a later stage).


# Solution description
- Added a new field in the `Team` model called `githubToken`, which would store the GitHub token.
- Created a `PATCH` api requests that updates the team details with the provided JSON object. This `PATCH` request is on the endpoint /team/:id , where ':id' is the id of the team. This supports updating all or part of the team's current details and also gives us a way to be able to store a GitHub token in the `Team` model.

# Tests 
All unit tests pass?
Yes

Builds successfully?
Yes

Attach screenshot of the expected result (e.g. UI of the website/ postman api call result/ database changes)
- Below is a `GET` request for a team.
![image](https://user-images.githubusercontent.com/80957318/118957433-dd631c80-b9a3-11eb-86ba-9a4f5b845304.png)
- Image below shows us make a `PATCH` request for that team. (Note: We provide a JSON object with the changes we want to make. Here we are trying to update the GitHub Token)
![image](https://user-images.githubusercontent.com/80957318/118957903-434fa400-b9a4-11eb-9fa3-30bac059cbab.png)
- Image below shows a `GET` request (the same request made earlier), and you can see the `githubToken` field is updated.
![image](https://user-images.githubusercontent.com/80957318/118958171-827df500-b9a4-11eb-961e-7a98bd412da2.png)


# Relevant document/ link (if any) 
Any related documents could help reviewers to review this PR 


# Risk
Identity the risk level (low, medium, high) and indicate which component(s) will be affected if bugs exist.
Low
