### PR TITLE
Optimizing scholarly lib

### DIFF
--- a/importpub/Dockerfile
+++ b/importpub/Dockerfile
@@ -2,8 +2,6 @@ FROM public.ecr.aws/lambda/python:3.8
 
 RUN pip3 install scholarly
 
-RUN pip3 install joblib
-
 # Copy function code
 COPY handler.py ./
 COPY gscholar.py ./

--- a/importpub/Dockerfile
+++ b/importpub/Dockerfile
@@ -2,6 +2,8 @@ FROM public.ecr.aws/lambda/python:3.8
 
 RUN pip3 install scholarly
 
+RUN pip3 install joblib
+
 # Copy function code
 COPY handler.py ./
 COPY gscholar.py ./

--- a/importpub/gscholar.py
+++ b/importpub/gscholar.py
@@ -8,7 +8,6 @@ import json
 def fill_pub(pub, conn):
     filled_pub = scholarly.fill(pub)
     del filled_pub["source"]
-    # pub_list.append(filled_pub)
     conn.send([filled_pub])
     conn.close()
 
@@ -18,7 +17,6 @@ def get_publications(author_id):
     :param author_id: google scholar user id extracted from their profile url
     :return: json string of publications in a list
     """
-    global pub_list
     search_query = scholarly.search_author_id(author_id)
     author_object = scholarly.fill(search_query, publication_limit=10)
     pub_list = []

--- a/importpub/gscholar.py
+++ b/importpub/gscholar.py
@@ -2,13 +2,15 @@
 This file contains the functions relating to getting publications from google scholar.
 """
 from scholarly import scholarly
-from joblib import Parallel, delayed
+from multiprocessing import Pipe, Process
 import json
 
-def fill_pub(pub):
+def fill_pub(pub, conn):
     filled_pub = scholarly.fill(pub)
     del filled_pub["source"]
-    pub_list.append(filled_pub)
+    # pub_list.append(filled_pub)
+    conn.send([filled_pub])
+    conn.close()
 
 def get_publications(author_id):
     """
@@ -21,7 +23,23 @@ def get_publications(author_id):
     author_object = scholarly.fill(search_query, publication_limit=10)
     pub_list = []
 
-    Parallel(n_jobs=2, prefer="threads")(delayed(fill_pub)(pub) for pub in author_object["publications"])
+    processes = []
+    parent_connections = []
 
+    for pub in author_object["publications"]:
+        parent_conn, child_conn = Pipe()
+        parent_connections.append(parent_conn)
+        process = Process(target=fill_pub, args=(pub,child_conn))
+        processes.append(process)
+
+    for process in processes:
+        process.start()
+
+    for process in processes:
+        process.join()
+
+    for parent_connection in parent_connections:
+        pub_list.append(parent_connection.recv()[0])
+        
     pub_json = json.dumps({ "publications": pub_list })
     return pub_json


### PR DESCRIPTION
# Description 
Parallelize getting the publications

# Type of change 
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation 


# Problem
Currently importing publications takes way too long, it takes 20 seconds to get author + 10 publications. Searching up the author takes around 5 seconds which is unavoidable so we have to optimize getting the publications. This is done by getting the info for each publication in parallel since they're independent.

# Solution description
Using the multiprocessing.Pipe function, it creates a parent and child pipe for each publication to get info for. The child fetches the info and then sends it to the parent. The processes are started in a for loop so they don't exactly start at the same time but close enough. The code doesn't continue until all the processes are finished. The parent receives it and puts the publication data into a list.

# Tests 
You can run it locally using Chunyang's Gscholar id: 3tyGlPsAAAAJ
And it should spit out something like:
![image](https://user-images.githubusercontent.com/40584352/118961720-fbcb1700-b9a7-11eb-8c02-5a2fac8f3582.png)



# Relevant document/ link (if any) 
Findings/times are documented here (I tried with joblib before but it wasn't working in the container/lambda): https://docs.google.com/document/d/1CrZi1HxeSRmjTsOq30PnOb9OFWUmn_djxgjCAYKQZRs/edit
I followed the example given here: https://aws.amazon.com/blogs/compute/parallel-processing-in-python-with-aws-lambda/



# Risk
LOW, standalone