### PR TITLE
Backend deploy fix

### DIFF
--- a/api/src/controllers/team.js
+++ b/api/src/controllers/team.js
@@ -34,7 +34,6 @@ const options = {
 async function storeHandle(req, res, next) {
   const { twitterHandle: handle } = req.body;
   let foundTeam = req.foundTeam;
-  console.log('in here');
 
   if (handle.length == 0) {
     // remove the handle from the doc

--- a/api/src/controllers/team.js
+++ b/api/src/controllers/team.js
@@ -223,16 +223,14 @@ async function deployToGHPages(req, res, next) {
     teamPublications: publications,
   };
 
-  await axios({
-    url: schollyHost + '/deploy/' + teamId,
-    method: 'post',
-    data: body,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  })
+  await axios
+    .post(`${schollyHost}/deploy/${teamId}`, body)
     .then(() => res.status(200).json('Successfully deployed'))
-    .catch(() => next(fillErrorObject(500, 'Server error', ["Error occurred with scholly"])));
+    .catch(() =>
+      next(
+        fillErrorObject(500, 'Server error', ['Error occurred with scholly'])
+      )
+    );
 }
 
 /**

--- a/api/src/controllers/team.js
+++ b/api/src/controllers/team.js
@@ -223,7 +223,7 @@ async function deployToGHPages(req, res, next) {
     teamPublications: publications,
   };
 
-  const schollyResponse = await axios({
+  await axios({
     url: schollyHost + '/deploy/' + teamId,
     method: 'post',
     data: body,
@@ -231,7 +231,7 @@ async function deployToGHPages(req, res, next) {
       'Content-Type': 'application/json',
     },
   })
-    .then(() => res.status(200).json(schollyResponse.data))
+    .then(() => res.status(200).json('Successfully deployed'))
     .catch(() => next(fillErrorObject(500, 'Server error', ["Error occurred with scholly"])));
 }
 

--- a/client/src/actions/team.js
+++ b/client/src/actions/team.js
@@ -23,13 +23,13 @@ import { errorActionGlobalCreator } from '../error/errorReduxFunctions';
  * @param teamInfo contains teamName, orgName and email
  */
 export const addTeamInfo = (teamInfo) => async (dispatch) => {
-  try{
+  try {
     const teamId = await api.addTeam(teamInfo);
     const teamData = {
       ...teamInfo,
       teamId: teamId,
     };
-    // TODO: do we need to dispatch this action? 
+    // TODO: do we need to dispatch this action?
     dispatch({
       type: ADD_TEAM,
       payload: teamData,
@@ -230,9 +230,7 @@ export const deployToGHPages =
   (teamId, accessToken, twitterHandle) => async (dispatch) => {
     try {
       // get publications
-      const { data } = await api.fetchPublicationsByTeamId(
-        '609f5ad827b1d48257c321d3' // FIXME: hardcoded for testing, remove after authentication is implemented
-      );
+      const { data } = await api.fetchPublicationsByTeamId(teamId);
       data.map(
         (pub) => (pub.yearPublished = pub.yearPublished.substring(0, 4))
       );
@@ -243,15 +241,13 @@ export const deployToGHPages =
         teamPublications: data,
       };
 
-      console.log(body);
-
       const response = await api.deployToGHPages(teamId, body);
       console.log(response.data);
       dispatch({
         type: DEPLOY_SUCCESS,
       }); // TODO: use this and DEPLOY_FAIL to show message to user?
     } catch (err) {
-      console.log(err);
+      dispatch(errorActionGlobalCreator(err));
       dispatch({
         type: DEPLOY_FAIL,
       });

--- a/client/src/components/deploy/DeployPage.js
+++ b/client/src/components/deploy/DeployPage.js
@@ -22,7 +22,6 @@ const DeployPage = () => {
     // github returns a code in the url after user logs in
     const url = window.location.href;
     const hasCode = url.includes('?code=');
-    console.log(teamId);
     if (hasCode && !retrievedAccessToken && teamId) {
       const code = url.split('?code=')[1];
       // we use this code to exchange an access token
@@ -66,8 +65,6 @@ const DeployPage = () => {
 
   return (
     <>
-      {/* <GitHubLoginButton />
-      <DeployButton />{' '} */}
       <ConditionalWrapper
         condition={retrievedAccessToken}
         wrapper={(children) => <DeployButton> {children}</DeployButton>}

--- a/client/src/components/deploy/DeployPage.js
+++ b/client/src/components/deploy/DeployPage.js
@@ -7,9 +7,6 @@ import { Button } from 'react-bootstrap';
 
 const DeployPage = () => {
   const dispatch = useDispatch();
-  // const teamId = useSelector((state) => state.team.teamId);
-  // FIXME: this is hardcoded because redirect from github loses team info after the redirect
-  // this issue should be fixed once authorization and jwt is implemented
   const teamId = useSelector((state) => state.team.teamId);
   const retrievedAccessToken = useSelector(
     (state) => state.team.retrievedAccessToken

--- a/client/src/components/deploy/DeployPage.js
+++ b/client/src/components/deploy/DeployPage.js
@@ -10,18 +10,20 @@ const DeployPage = () => {
   // const teamId = useSelector((state) => state.team.teamId);
   // FIXME: this is hardcoded because redirect from github loses team info after the redirect
   // this issue should be fixed once authorization and jwt is implemented
-  const teamId = '60e92f81eaefdcaaa3ac724c';
+  const teamId = useSelector((state) => state.team.teamId);
   const retrievedAccessToken = useSelector(
     (state) => state.team.retrievedAccessToken
   );
   const linkedHandle = useSelector((state) => state.team.twitterHandle);
+  const ConditionalWrapper = ({ condition, wrapper, children }) =>
+    condition ? wrapper(children) : children;
 
   useEffect(() => {
     // github returns a code in the url after user logs in
     const url = window.location.href;
     const hasCode = url.includes('?code=');
-
-    if (hasCode && !retrievedAccessToken) {
+    console.log(teamId);
+    if (hasCode && !retrievedAccessToken && teamId) {
       const code = url.split('?code=')[1];
       // we use this code to exchange an access token
       dispatch(getGHAccessToken(teamId, code));
@@ -29,7 +31,7 @@ const DeployPage = () => {
       // we refreshed so we should clear local storage
       localStorage.clear();
     }
-  }, [dispatch]);
+  }, [dispatch, teamId]);
 
   const GitHubLoginButton = () => (
     <Button
@@ -63,8 +65,14 @@ const DeployPage = () => {
 
   return (
     <>
-      <GitHubLoginButton />
-      <DeployButton />{' '}
+      {/* <GitHubLoginButton />
+      <DeployButton />{' '} */}
+      <ConditionalWrapper
+        condition={retrievedAccessToken}
+        wrapper={(children) => <DeployButton> {children}</DeployButton>}
+      >
+        <GitHubLoginButton />
+      </ConditionalWrapper>
     </>
   );
 };

--- a/client/src/components/deploy/DeployPage.js
+++ b/client/src/components/deploy/DeployPage.js
@@ -31,6 +31,7 @@ const DeployPage = () => {
       // we refreshed so we should clear local storage
       localStorage.clear();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, teamId]);
 
   const GitHubLoginButton = () => (


### PR DESCRIPTION
# Description 
Before the deploy to scholly endpoint was using a hardcoded teamid due to the Github redirect back to Researchify losing all login information. Now with access tokens properly implemented, this is no longer the case and the teamid can be retrieved from the state after the redirect.

# Type of change 
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation 


# Problem
See description

# Solution description
Describe your code changes in detail for reviewers. 
Explain the technical solution you have provided and how it fixes the issue.


# Tests 
Make a new account, add some publications, and then go to the deploy page to deploy.
You can put a `console.log(body)` in /api/controllers/team.js after line 225 to check whether the publications you just added are being passed through properly.

# Relevant document/ link (if any) 
N/A

# Risk
Identity the risk level (low, medium, high) and indicate which component(s) will be affected if bugs exist.
Low, just the deploy flow will be affected