### PR TITLE
Team profile redux state reset on refresh

### DIFF
--- a/api/src/controllers/auth.js
+++ b/api/src/controllers/auth.js
@@ -31,10 +31,7 @@ const { accessTokenExpiry, refreshTokenExpiry, accessTokenCookieExpiry, refreshT
 
     if (await bcrypt.compare(req.body.password, foundTeam.password)){
       const jwtPayload = {
-        _id: foundTeam._id,
-        email: foundTeam.email,
-        teamName: foundTeam.teamName,
-        orgName: foundTeam.orgName
+        _id: foundTeam._id
       }
 
       const accessToken = jwt.sign({ team: jwtPayload }, process.env.JWT_SECRET_ACCESS_TOKEN || "JWT_SECRET_ACCESS_TOKEN", {

--- a/api/src/controllers/team.js
+++ b/api/src/controllers/team.js
@@ -71,13 +71,19 @@ async function storeHandle(req, res, next) {
 }
 
 /**
- * Gets the team document from the auth middleware
- * @param {*} req request object, containing the team object 
- * @param {*} res response object, the team object 
- * @returns 200: return the team passed by the auth middleware 
+ * Gets the team info
+ * @param {*} req request object contains the teamId decoded in auth middleware
+ * @param {*} res response object, the team related info 
+ * @returns 200: the team related info  
  */
-function getTeam(req, res) {
-  return res.status(200).send(req.team);
+function getTeam(req, res, next) {
+  Team.findById(req.team._id).select('_id teamName orgName email')
+  .then((foundTeam) => {
+    if (foundTeam) {
+      return res.status(200).send(foundTeam);
+    }
+  })
+  .catch((err) => next(fillErrorObject(500, 'Server error', [err.errors])));
 }
 
 /**

--- a/client/src/components/profileInfoEdit/ProfileInfoEdit.js
+++ b/client/src/components/profileInfoEdit/ProfileInfoEdit.js
@@ -25,7 +25,7 @@ const ProfileInfoEdit = () => {
 
   useEffect(() => {
     setInputs({teamName, orgName, email})
-  }, [email, orgName, teamId, teamName])
+  }, [email, orgName, teamName])
   
   const updateInputs = (form) => {
     const { name, value } = form.target;

--- a/client/src/components/profileInfoEdit/ProfileInfoEdit.js
+++ b/client/src/components/profileInfoEdit/ProfileInfoEdit.js
@@ -2,7 +2,7 @@
  * This file exports a profile page management component that displays the ability to edit user information
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { Button, Form, Container, Image } from 'react-bootstrap';
 import './ProfileInfoEdit.css';
@@ -19,13 +19,13 @@ import { updateTeam } from '../../actions/team';
 const ProfileInfoEdit = () => {
   const dispatch = useDispatch(); 
 
-  const teamId = useSelector((state) => state.team?.teamId);
+  const { teamId, teamName, orgName, email } = useSelector((state) => state.team);
 
-  const [profileData, setInputs] = useState({
-    teamName: useSelector((state) => state.team?.teamName),
-    orgName: useSelector((state) => state.team?.orgName),
-    email: useSelector((state) => state.team?.email),
-  });
+  const [profileData, setInputs] = useState({ teamName, orgName, email});
+
+  useEffect(() => {
+    setInputs({teamName, orgName, email})
+  }, [email, orgName, teamId, teamName])
   
   const updateInputs = (form) => {
     const { name, value } = form.target;


### PR DESCRIPTION
# Description 
There are 2 issues on the team profile page currently: 
1. the team information on the form will be cleared after refreshing the page 
2. after updating the team information and refresh the page, the profile will revert back to the previous team information 

# Type of change 
- [X] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation 


# Problem
The problem with the above issue is that we had contains the teamName, orgName, and email in the JWT payload, and the way we send the team info from the backend to the frontend is by decoding the jwt payload. As a result, the team info will always show the old information unless we generate the new access token. 

# Solution description
Change the jwt payload to only contain the teamId, as it is not editable by users and then make request to the database to return the team info using the teamId
Also, use the useEffect hook to update the team info on the form whenever the relevant info is returned from the backend


# Tests 
All unit tests pass? N/A

Builds successfully? Yes 


Attach screenshot of the expected result (e.g. UI of the website/ postman api call result/ database changes)
N/A

Provide steps in detail for reviewers to reproduce the expected result of the code changes.
The issue described in the description section should be fixed in this PR

# Relevant document/ link (if any) 
Any related documents could help reviewers to review this PR 


# Risk
Low
