### PR TITLE
Fix add pages bug

### DIFF
--- a/api/src/routes/publications.js
+++ b/api/src/routes/publications.js
@@ -32,7 +32,7 @@ publicationsRouter.post(
 
 publicationsRouter.get(
   '/import/:gScholarUserId/:startFrom/validate/:team_id',
-  // authMiddleware.cookieJwtAuth,
+  authMiddleware.cookieJwtAuth,
   mongooseMiddleware.validateTeamObjectId,
   teamMiddleware.validateTeamId,
   publicationsMiddleware.validateAuthorId,

--- a/client/src/components/dashboard/webpage/WebpageSelector.js
+++ b/client/src/components/dashboard/webpage/WebpageSelector.js
@@ -26,6 +26,7 @@ const WebpageSelector = ({ currentWebPages, teamId, closeModal, displayModal }) 
 
   const handleSubmit = () => {
     dispatch(addPage(teamId, selectedPage));
+    setSelectedPage(pagePlaceholder);
     closeModal();
   };
   

--- a/client/src/components/dashboard/webpage/Webpages.js
+++ b/client/src/components/dashboard/webpage/Webpages.js
@@ -114,7 +114,7 @@ const Webpages = ({
           <tbody>
             <tr key="default-homepage">
               <td className="body">
-                {'HOMEPAGE'}
+                HOMEPAGE
                 <Button
                   variant="outline-success"
                   className="action float-right mx-2"

--- a/client/src/components/dashboard/webpage/Webpages.js
+++ b/client/src/components/dashboard/webpage/Webpages.js
@@ -114,7 +114,7 @@ const Webpages = ({
           <tbody>
             <tr key="default-homepage">
               <td className="body">
-                {'HOME PAGE'}
+                {'HOMEPAGE'}
                 <Button
                   variant="outline-success"
                   className="action float-right mx-2"


### PR DESCRIPTION
# Description 
The webpage selector has a bug where you can add the same page more than once because when you go to add a page after the first time, the dropdown doesn't clear and still has the option to add the same page.

# Type of change 
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation 


# Problem
See description
![image](https://user-images.githubusercontent.com/40584352/130437885-ce454265-3ef4-46b0-bc5b-5782a595984b.png)


# Solution description
setSelectedPage needs to reset after a page has been added
Also fixed a typo


# Tests 
Start from a fresh state with no pages added, add publications, then go to add again and the dropdown button shouldn't have publications anymore


# Relevant document/ link (if any) 
Any related documents could help reviewers to review this PR 
N/A

# Risk
Identity the risk level (low, medium, high) and indicate which component(s) will be affected if bugs exist.
Low