### PR TITLE
Make images for theme colour and layout clickable

### DIFF
--- a/client/src/actions/auth.js
+++ b/client/src/actions/auth.js
@@ -8,7 +8,6 @@ import {
   LOG_OUT,
   LOG_IN_FAIL,
   FETCH_TEAM_INFO,
-  CLEAR_NOTIFICATION,
   FETCH_WEBSITE_INFO,
 } from './types';
 import { errorActionGlobalCreator } from '../notification/notificationReduxFunctions';
@@ -58,10 +57,6 @@ export const logout = () => async (dispatch) => {
     await api.logoutTeam();
     dispatch({
       type: LOG_OUT,
-    });
-
-    dispatch({
-      type: CLEAR_NOTIFICATION,
     });
   } catch (err) {
     dispatch(errorActionGlobalCreator(err));

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,5 +1,6 @@
 /**
- * This index file will export combined reducers.
+ * This index file will export combined reducers
+ * When the logout action is dispatched, all reducers will be initialzed to thir initial state
  */
 import { combineReducers } from 'redux';
 
@@ -13,8 +14,9 @@ import notificationReducer from './notificationReducer';
 import deployReducer from './deployReducer';
 import achievementsReducer from './achievementsReducer';
 import homepageReducer from './homepageReducer';
+import { LOG_OUT } from '../actions/types';
 
-export default combineReducers({
+const appReducer =  combineReducers({
   notification: notificationReducer,
   auth: authReducer,
   publications: publicationsReducer,
@@ -26,3 +28,12 @@ export default combineReducers({
   achievements: achievementsReducer, 
   homepage: homepageReducer,
 });
+
+const rootReducer = (state, action) => {
+  if (action.type === LOG_OUT) {
+    return appReducer(undefined, action)
+  }
+  return appReducer(state, action)
+}
+
+export default rootReducer


### PR DESCRIPTION
# Description 
On the Theme selector page, the images are currently not clickable. In order to select a theme colour or layout, you need to select the checkbox. This PR makes these images clickable so you now have another way of selecting a theme and layout.


# Type of change 
- [ ] Bug fix
- [x] New feature
- [x] Refactoring
- [ ] Documentation 


# Problem
Images in the theme selector were not clickable.


# Solution description
Made the images for both theme and layout have onClick actions which result in the corresponding radio button to be checked whilst also ensuring the correct information regarding theme and layout is stored in the state.

# Tests 
All unit tests pass? Yes

Builds successfully? Yes

Attach screenshot of the expected result (e.g. UI of the website/ postman api call result/ database changes)
Before:
![image](https://user-images.githubusercontent.com/80957318/130954346-828f5e0c-caf0-4ff2-a7bb-cc7d97450d53.png)

After clicking on the image for layout 3 and the image for the black and white theme:
![image](https://user-images.githubusercontent.com/80957318/130954467-faf87419-a500-472a-b2cf-9aaf5da0e245.png)




# Risk
Identity the risk level (low, medium, high) and indicate which component(s) will be affected if bugs exist.
Low