### PR TITLE
Fix import publications bug with category types

### DIFF
--- a/api/src/controllers/publications.js
+++ b/api/src/controllers/publications.js
@@ -234,9 +234,9 @@ async function scrapeGoogleScholar(url) {
 
   // TODO: this logic depends on the order of the fields,
   // which will differ based on the info of the publication, can be improved
-  let type = fields[2].toUpperCase();
+  let type = fields[2];
   let categoryTitle;
-  if (!(type in categoryTypes)) {
+  if (!(categoryTypes.includes(type))) {
     type = 'Other';
     categoryTitle = '';
   } else {

--- a/client/src/components/publications/form/PublicationForm.js
+++ b/client/src/components/publications/form/PublicationForm.js
@@ -22,7 +22,7 @@ const PublicationForm = (props) => {
     description: '',
     link: '',
     category: {
-      type: categoryTypes.JOURNAL,
+      type: categoryTypes.Journal,
       categoryTitle: '',
       volume: '',
       issue: '',

--- a/client/src/components/publications/importedPublication/ImportedPublication.js
+++ b/client/src/components/publications/importedPublication/ImportedPublication.js
@@ -21,57 +21,47 @@ const ImportedPublication = ({ pub, index, setChecked }) => {
           {pub.category.type.charAt(0)
             + pub.category.type.slice(1).toLowerCase()}
           :
-          {' '}
-          {pub.category.categoryTitle}
+          {` ${pub.category.categoryTitle}`}
         </h6>
         {pub.category.issue && (
         <h6>
-          {' '}
           Issue:
-          {pub.category.issue}
+          {` ${pub.category.issue}`}
         </h6>
         )}
         {pub.category.volume && (
         <h6>
-          {' '}
           Volume:
-          {pub.category.volume}
+          {` ${pub.category.volume}`}
         </h6>
         )}
         {pub.category.pages && (
         <h6>
-          {' '}
           Pages:
-          {pub.category.pages}
+          {` ${pub.category.pages}`}
         </h6>
         )}
         {pub.category.publisher && (
           <h6>
-            {' '}
             Publisher:
-            {pub.category.publisher}
+            {` ${pub.category.publisher}`}
           </h6>
         )}
         <h6>
-          {' '}
           Description:
-          {pub.description}
+          {` ${pub.description}`}
         </h6>
         {/* { pub.link && <h6> Link: <a style={{cursor: 'pointer'}} onClick={() => window.open(`${pub.link}`, '_blank')}>{pub.link} </a> </h6> } */}
         {pub.link && (
           <h6>
-            {' '}
             Link:
-            {' '}
             <a
               href={pub.link}
               style={{ cursor: 'pointer' }}
               onClick={() => window.open(`${pub.link}`, '_blank')} // eslint-disable-line no-undef
             >
-              {pub.link}
-              {' '}
+              {` ${pub.link}`}
             </a>
-            {' '}
           </h6>
         )}
       </div>

--- a/client/src/components/publications/publicationsLayout/LayoutAllPublications.js
+++ b/client/src/components/publications/publicationsLayout/LayoutAllPublications.js
@@ -1,7 +1,7 @@
 /**
  * The LayoutAllPublications component displays a list of publications
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 import usePagination from '../../shared/usePagination';
 import Publication from '../publication/Publication';
 import { pageSize as configPageSize } from '../../../config/publications';

--- a/client/src/components/publications/publicationsLayout/LayoutByCategory.js
+++ b/client/src/components/publications/publicationsLayout/LayoutByCategory.js
@@ -8,7 +8,7 @@ import LayoutAllPublications from './LayoutAllPublications';
 const LayoutByCategory = ({ teamPublications }) => {
   const renderPublicationsByCategory = (categoryType) => {
     const publicationsByCategory = teamPublications.filter(
-      (pub) => pub.category.type === categoryType.toUpperCase(),
+      (pub) => pub.category.type === categoryType,
     );
     return (
       publicationsByCategory.length > 0 && (

--- a/client/src/config/publications.js
+++ b/client/src/config/publications.js
@@ -4,10 +4,10 @@
 const pageSize = 10;
 const categoryPageSize = 5;
 const categoryTypes = {
-  JOURNAL: 'Journal',
-  CONFERENCE: 'Conference',
-  BOOK: 'Book',
-  OTHER: 'Other',
+  Journal: 'Journal',
+  Conference: 'Conference',
+  Book: 'Book',
+  Other: 'Other',
 };
 const layoutOptions = {
   ALL_PUBLICATION: 'All Publication',

--- a/scholly/base/src/components/publications/publicationsLayout/LayoutByCategory.js
+++ b/scholly/base/src/components/publications/publicationsLayout/LayoutByCategory.js
@@ -8,7 +8,7 @@
  const LayoutByCategory = ({ teamPublications }) => {
   const renderPublicationsByCategory = (categoryType) => {
     const publicationsByCategory = teamPublications.filter(
-      (pub) => pub.category.type === categoryType.toUpperCase()
+      (pub) => pub.category.type === categoryType
     );
     return (
       publicationsByCategory.length > 0 && (

--- a/scholly/base/src/config/publications.js
+++ b/scholly/base/src/config/publications.js
@@ -4,10 +4,10 @@
 const pageSize = 10;
 const categoryPageSize = 5;
 const categoryType = {
-  JOURNAL: 'Journal',
-  CONFERENCE: 'Conference',
-  BOOK: 'Book',
-  OTHER: 'Other',
+  Journal: 'Journal',
+  Conference: 'Conference',
+  Book: 'Book',
+  Other: 'Other',
 };
 const layoutOption = {
   ALL_PUBLICATION: 'All Publication',


### PR DESCRIPTION
# Description 
The refactoring of category types for the publications from PR#171 broke some of the code from import publications logic in the backend which means every imported publication gets classified as 'Other'. 

# Type of change 
- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation 


# Problem
See description
![image](https://user-images.githubusercontent.com/40584352/131326039-6468894b-40b3-4424-9a63-60d516b42975.png)


# Solution description
Backend logic had to be fixed to not compare using uppercase and use comparisons for an array since `categoryType` is not an object anymore
The frontend/scholly base code also needed to be changed to not use uppercase in comparisons, because this broke the publications layout by category. This also broke add publications since it's using the `categoryTypes` object.
Also did some refactoring so that a space would appear after the colon in the publications details


# Tests 
Try importing and checking that the publications get classified properly, and change the layout to sort by category. Also try deploying the site and checking that sort by category works.

# Relevant document/ link (if any) 
N/A

# Risk
Identity the risk level (low, medium, high) and indicate which component(s) will be affected if bugs exist.
Medium, scholly base, client publications page, import logic in backend