### PR TITLE
Error toast not showing up on register page 

### DIFF
--- a/client/src/components/auth/RegistrationForm.js
+++ b/client/src/components/auth/RegistrationForm.js
@@ -60,8 +60,9 @@ export default function RegistrationForm() {
   };
 
   const submitForm = (values) => {
-    delete values.confirmedPassword;
-    dispatch(createTeam(values));
+    const teamInfo = { ...values };
+    delete teamInfo.confirmedPassword;
+    dispatch(createTeam(teamInfo));
   };
 
   return (


### PR DESCRIPTION
# Description 
Toast shows once when a user enters a used email. Toast fails to popup a second time when a user registers with the same email again.

# Type of change 
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation 


# Problem
Briefly describe the root cause and analysis of the problem 
![image](https://user-images.githubusercontent.com/17608976/132335479-ad20ba3b-735c-4501-b381-52f1a60eeb41.png)
This error shows in the console when a user registers with the same email again. It's because in the code we deleted the confirmed password before dispatching the createTeam action, so for the second time onwards, the confirmed password is undefined, and the input becomes uncontrolled, which cause the error. 

# Solution description
Instead of deleting the confirmed password from the `values` object, a new variable, which is a copy of  `values` object is created. We can then delete the confirmed password from the new variable before dispatching it. 


# Tests 
All unit tests pass? N/A

Builds successfully? Yes


Attach screenshot of the expected result (e.g. UI of the website/ postman api call result/ database changes)


Provide steps in detail for reviewers to reproduce the expected result of the code changes.
The error toast should pop up when a user registers with the same email for the second time onwards. 


# Relevant document/ link (if any) 
Any related documents could help reviewers to review this PR 


# Risk
Identity the risk level (low, medium, high) and indicate which component(s) will be affected if bugs exist.
Low