### PR TITLE
Password requiremtn+ message + toast position

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -26,7 +26,7 @@ const App = () => {
 
   return (
     <>
-      <Toaster position="bottom-center" reverseOrder={false} />
+      <Toaster position="top-center" reverseOrder={false} />
       <BrowserRouter>
         <NotificationToaster />
         { logIn ? <PrivateRoute /> : <PublicRoute /> }

--- a/client/src/components/auth/authComponents/RegistrationForm.jsx
+++ b/client/src/components/auth/authComponents/RegistrationForm.jsx
@@ -64,7 +64,7 @@ const RegistrationForm = () => {
       .required('Please enter your password')
       .matches(
         /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
-        'Password is not strong enough',
+        'Password must contain 8 characters, 1 uppercase, 1 lowercase, 1 number and 1 symbol.',
       ),
     confirmedPassword: yup
       .string()

--- a/client/src/components/auth/authComponents/RegistrationForm.jsx
+++ b/client/src/components/auth/authComponents/RegistrationForm.jsx
@@ -29,7 +29,7 @@ const StringPasswordHint = (props) => (
       - 8-20 characters
       <br />
       {' '}
-      - At least 1 alphabet letter
+      - At least 1 lower/upper character
       <br />
       {' '}
       - At least 1 number
@@ -60,7 +60,7 @@ const RegistrationForm = () => {
       .max(20, 'Password is too long')
       .matches(
         /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,20}$/,
-        'Password must contain at least 8 characters, 1 alphabet and 1 number',
+        'Password must contain at least 8 characters, including \n1 lower/upper character and 1 number',
       ),
     confirmedPassword: yup
       .string()

--- a/client/src/components/auth/authComponents/RegistrationForm.jsx
+++ b/client/src/components/auth/authComponents/RegistrationForm.jsx
@@ -36,9 +36,6 @@ const StringPasswordHint = (props) => (
       <br />
       {' '}
       - At least 1 number
-      <br />
-      {' '}
-      - At least 1 symbol from @$!%*#?&
     </Popover.Content>
   </Popover>
 );

--- a/client/src/components/auth/authComponents/RegistrationForm.jsx
+++ b/client/src/components/auth/authComponents/RegistrationForm.jsx
@@ -148,7 +148,7 @@ const RegistrationForm = () => {
               <Form.Label>
                 Password
                 {'  '}
-                <OverlayTrigger trigger="hover" placement="right" overlay={StringPasswordHint}>
+                <OverlayTrigger trigger={['hover', 'focus']} placement="right" overlay={StringPasswordHint}>
                   <BsQuestionCircle style={{ color: 'grey' }} />
                 </OverlayTrigger>
               </Form.Label>

--- a/client/src/components/auth/authComponents/RegistrationForm.jsx
+++ b/client/src/components/auth/authComponents/RegistrationForm.jsx
@@ -60,7 +60,7 @@ const RegistrationForm = () => {
       .max(20, 'Password is too long')
       .matches(
         /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,20}$/,
-        'Password must be 8 or more characters with a mix of \nletters and numbers',
+        'Password must be 8 or more characters with a mix of letters and numbers',
       ),
     confirmedPassword: yup
       .string()

--- a/client/src/components/auth/authComponents/RegistrationForm.jsx
+++ b/client/src/components/auth/authComponents/RegistrationForm.jsx
@@ -29,10 +29,7 @@ const StringPasswordHint = (props) => (
       - 8-20 characters
       <br />
       {' '}
-      - At least 1 uppercase letter
-      <br />
-      {' '}
-      - At least 1 lowercase letter
+      - At least 1 alphabet letter
       <br />
       {' '}
       - At least 1 number
@@ -63,7 +60,7 @@ const RegistrationForm = () => {
       .max(20, 'Password is too long')
       .matches(
         /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,20}$/,
-        'Password must contain at least 8 characters, 1 uppercase, \n1 lowercase and 1 number',
+        'Password must contain at least 8 characters, 1 alphabet and 1 number',
       ),
     confirmedPassword: yup
       .string()

--- a/client/src/components/auth/authComponents/RegistrationForm.jsx
+++ b/client/src/components/auth/authComponents/RegistrationForm.jsx
@@ -64,7 +64,7 @@ const RegistrationForm = () => {
       .required('Please enter your password')
       .matches(
         /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
-        'Password must contain 8 characters, 1 uppercase, 1 lowercase, 1 number and 1 symbol.',
+        'Password must contain 8 characters, 1 uppercase, \n1 lowercase, 1 number and 1 symbol.',
       ),
     confirmedPassword: yup
       .string()
@@ -161,7 +161,7 @@ const RegistrationForm = () => {
                 onChange={handleChange}
                 isInvalid={touched.password && errors.password}
               />
-              <Form.Control.Feedback type="invalid">
+              <Form.Control.Feedback type="invalid" style={{ whiteSpace: 'pre-wrap' }}>
                 {errors.password}
               </Form.Control.Feedback>
             </Form.Group>

--- a/client/src/components/auth/authComponents/RegistrationForm.jsx
+++ b/client/src/components/auth/authComponents/RegistrationForm.jsx
@@ -62,9 +62,11 @@ const RegistrationForm = () => {
     password: yup
       .string()
       .required('Please enter your password')
+      .min(8, 'Password must contain at least 8 characters')
+      .max(20, 'Password is too long')
       .matches(
-        /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/,
-        'Password must contain 8 characters, 1 uppercase, \n1 lowercase, 1 number and 1 symbol.',
+        /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,20}$/,
+        'Password must contain at least 8 characters, 1 uppercase, \n1 lowercase and 1 number',
       ),
     confirmedPassword: yup
       .string()

--- a/client/src/components/auth/authComponents/RegistrationForm.jsx
+++ b/client/src/components/auth/authComponents/RegistrationForm.jsx
@@ -29,7 +29,7 @@ const StringPasswordHint = (props) => (
       - 8-20 characters
       <br />
       {' '}
-      - At least 1 lower/upper character
+      - At least 1 letter
       <br />
       {' '}
       - At least 1 number
@@ -60,7 +60,7 @@ const RegistrationForm = () => {
       .max(20, 'Password is too long')
       .matches(
         /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,20}$/,
-        'Password must contain at least 8 characters, including \n1 lower/upper character and 1 number',
+        'Password must be 8 or more characters with a mix of \nletters and numbers',
       ),
     confirmedPassword: yup
       .string()


### PR DESCRIPTION
# Description 
Tiny PR. Changed password message in registration form + toast position to top. Also made the password requirement easier.

# Type of change 
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation 


# Problem
The toast position at the bottom centre is easy to be ignored by users. Top centre is also google chrome default notification posittion.



# Tests 
All unit tests pass? Y

Builds successfully? Y


Attach screenshot of the expected result (e.g. UI of the website/ postman api call result/ database changes)
![toast](https://user-images.githubusercontent.com/48777884/135778039-e1dd88b7-1cde-440b-b57c-d5d0aef8efa4.png)
![password](https://user-images.githubusercontent.com/48777884/135782620-93ac3757-7e8d-4850-9476-f7b48d587479.png)



# Relevant document/ link (if any) 
Any related documents could help reviewers to review this PR 


# Risk
Tiny
