### PR TITLE
Backend Team Delete

### DIFF
--- a/api/src/controllers/team.js
+++ b/api/src/controllers/team.js
@@ -16,9 +16,186 @@ const {
 const { fillErrorObject } = require('../middleware/error');
 
 /**
+ * Handles a POST request to create a team on the endpoint /team.
+ * A post-hook/middleware is associated with the {@link Team} model that will
+ * create default-initialized dependent documents for the team being created.
+ *
+ * @param req request object containing at least two fields: teamName & orgName.
+ * @param res response object - updated team object
+ * @param next handler to the next middleware
+ * @returns 201: returns updated team details
+ */
+async function createTeam(req, res, next) {
+  const foundTeam = await Team.findOne({ email: req.body.email });
+  if (foundTeam) {
+    return next(
+      fillErrorObject(400, 'Duplicate email error', [
+        'Email had been registered',
+      ]),
+    );
+  }
+  const salt = await bcrypt.genSalt();
+  const hashedPassword = await bcrypt.hash(req.body.password, salt);
+  const hashedTeam = {
+    ...req.body,
+    password: hashedPassword,
+  };
+  const createdTeam = await Team.create(hashedTeam);
+  // remove sensitive data
+  delete createTeam.password;
+  return res.status(201).json(createdTeam);
+}
+
+/**
+ * Gets the team info
+ * @param {*} req request object contains the teamId decoded in auth middleware
+ * @param {*} res response object, the team related info
+ * @param next handler to the next middleware
+ * @returns 200: the team related info
+ */
+function getTeam(req, res, next) {
+  Team.findById(req.team._id)
+    .select('_id teamName orgName email twitterHandle profilePic')
+    .then((foundTeam) => {
+      if (foundTeam) {
+        return res.status(200).send(foundTeam);
+      }
+      return next(fillErrorObject(404, 'Team not found',
+        ['Team with the given id could not be found']));
+    })
+    .catch((err) => next(fillErrorObject(500, 'Server error', [err.errors])));
+}
+
+/**
+ * Update the team from the database on /team/:teamId
+ * @param req request object, containing team id in the url
+ * @param res response object, the updated team document
+ * @param next handler to the next middleware
+ * @returns 200: team updated
+ * @returns 404: team is not found
+ * @returns 400: team id is not in a valid hexadecimal format
+ */
+async function updateTeam(req, res, next) {
+  const { teamId: _id } = req.params;
+  const team = req.body;
+
+  try {
+    const updatedTeam = await Team.findByIdAndUpdate(_id, team, {
+      new: true,
+      runValidators: true,
+    });
+    return res.status(200).json(updatedTeam);
+  } catch (err) {
+    return next(fillErrorObject(500, 'Server error', [err]));
+  }
+}
+
+/**
+ * Handles a DELETE request to remove a team on the endpoint /team/:teamId.
+ * A post-hook/middleware is associated with the {@link Team} model that will
+ * delete all dependent documents for the team being deleted.
+ *
+ * @param req request object
+ * @param res response object
+ * @param next handler to the next middleware
+ * @returns 204 no content, if the delete was successful
+ * @returns 500 if a server error occurred
+ */
+async function deleteTeam(req, res, next) {
+  const { foundTeam } = req;
+  try {
+    await foundTeam.remove();
+    return res.status(204).send();
+  } catch (err) {
+    return next(fillErrorObject(500, 'Server error', [err]));
+  }
+}
+
+/**
+ * POST request to create a new team member to the database on /team/:teamId/member.
+ * @param {*} req request object, containing team id in the url
+ * @param {*} res response object, the created team member document
+ * @param next handler to the next middleware
+ * @returns 200: the team member was created
+ * @returns 404: team is not found
+ * @returns 400: team id is not in a valid hexadecimal format
+ */
+function createTeamMember(req, res, next) {
+  let teamMember = req.body;
+  const memberId = new mongoose.Types.ObjectId();
+  const { foundTeam } = req;
+  teamMember = {
+    ...teamMember,
+    _id: memberId,
+  };
+
+  foundTeam.teamMembers.push(teamMember);
+  foundTeam
+    .save()
+    .then(() => res.status(200).json(teamMember))
+    .catch((err) => next(fillErrorObject(500, 'Server error', [err])));
+}
+
+/**
+ * Gets the team member array from the database on /team/:teamId/member.
+ * @param {*} req request object, containing team id in the url
+ * @param {*} res response object, the returned team member array
+ * @returns 200: the team member array was returned
+ * @returns 404: team is not found
+ * @returns 400: team id is not in a valid hexadecimal format
+ */
+function readTeamMembersByTeam(req, res) {
+  const { foundTeam } = req;
+  return res.status(200).send(foundTeam.teamMembers);
+}
+
+/**
+ * Update the team member from the database on /team/:teamId/member.
+ * @param {*} req request object, containing team id in the url
+ * @param {*} res response object, the updated team member document
+ * @param next handler to the next middleware
+ * @returns 200: the team member was updated
+ * @returns 404: team is not found
+ * @returns 400: team id is not in a valid hexadecimal format
+ */
+function updateTeamMember(req, res, next) {
+  const updatedTeamMember = req.body;
+  Team.updateOne(
+    { 'teamMembers._id': updatedTeamMember._id },
+    {
+      $set: {
+        'teamMembers.$': updatedTeamMember,
+      },
+    },
+  )
+    .then(() => res.status(200).json(updatedTeamMember))
+    .catch((err) => next(fillErrorObject(500, 'Server error', [err])));
+}
+
+/**
+ * Delete the team member from the database on /team/:teamId/member/:member_id.
+ * @param {*} req request object, containing team id in the url
+ * @param {*} res response object, the relevant message returned
+ * @param next handler to the next middleware
+ * @returns 200: the team member was deleted
+ * @returns 404: team is not found
+ * @returns 400: team id is not in a valid hexadecimal format
+ */
+function deleteTeamMember(req, res, next) {
+  const { foundTeam } = req;
+  const { memberId } = req.params;
+  foundTeam.teamMembers.pull({ _id: memberId });
+  foundTeam
+    .save()
+    .then(() => res.status(200).json(foundTeam.teamMembers))
+    .catch((err) => next(fillErrorObject(500, 'Server error', [err])));
+}
+
+/**
  * Associates a twitter handle with a team on the /team/twitter-handle/:teamId endpoint.
  * @param {*} req request object, containing the teamId in the url and twitter handle in the body
  * @param {*} res response object
+ * @param next handler to the next middleware
  * @returns 200: successful added twitter handle to team
  * @returns 400: team id is not in a valid hexadecimal format
  * @returns 404: team is not found, or handle is invalid
@@ -65,122 +242,6 @@ async function storeHandle(req, res, next) {
   } catch (err) {
     return next(fillErrorObject(500, 'Server error', [err.errors]));
   }
-}
-
-/**
- * Gets the team info
- * @param {*} req request object contains the teamId decoded in auth middleware
- * @param {*} res response object, the team related info
- * @returns 200: the team related info
- */
-function getTeam(req, res, next) {
-  Team.findById(req.team._id)
-    .select('_id teamName orgName email twitterHandle profilePic')
-    .then((foundTeam) => {
-      if (foundTeam) {
-        return res.status(200).send(foundTeam);
-      }
-      return next(fillErrorObject(404, 'Team not found', ['Team with the given id could not be found']));
-    })
-    .catch((err) => next(fillErrorObject(500, 'Server error', [err.errors])));
-}
-
-/**
- * Handles a POST request to add a team on the endpoint /team.
- * @param {*} req request object -  json object containing at least two fields - teamName and orgName.
- * @param {*} res response object - updated team object
- * @returns 201: returns updated team details
- */
-async function createTeam(req, res, next) {
-  const foundTeam = await Team.findOne({ email: req.body.email });
-  if (foundTeam) {
-    return next(
-      fillErrorObject(400, 'Duplicate email error', [
-        'Email had been registered',
-      ]),
-    );
-  }
-  const salt = await bcrypt.genSalt();
-  const hashedPassword = await bcrypt.hash(req.body.password, salt);
-  const hashedTeam = { ...req.body, password: hashedPassword };
-  const createdTeam = await Team.create(hashedTeam);
-  // remove sensitive data
-  delete createTeam.password;
-  return res.status(201).json(createdTeam);
-}
-
-/**
- * Gets the team member array from the database on /team/:teamId/member.
- * @param {*} req request object, containing team id in the url
- * @param {*} res response object, the returned team member array
- * @returns 200: the team member array was returned
- * @returns 404: team is not found
- * @returns 400: team id is not in a valid hexadecimal format
- */
-function readTeamMembersByTeam(req, res) {
-  const { foundTeam } = req;
-  return res.status(200).send(foundTeam.teamMembers);
-}
-
-/**
- * POST request to create a new team member to the database on /team/:teamId/member.
- * @param {*} req request object, containing team id in the url
- * @param {*} res response object, the created team member document
- * @returns 200: the team member was created
- * @returns 404: team is not found
- * @returns 400: team id is not in a valid hexadecimal format
- */
-function createTeamMember(req, res, next) {
-  let teamMember = req.body;
-  const memberId = new mongoose.Types.ObjectId();
-  const { foundTeam } = req;
-  teamMember = { ...teamMember, _id: memberId };
-
-  foundTeam.teamMembers.push(teamMember);
-  foundTeam
-    .save()
-    .then(() => res.status(200).json(teamMember))
-    .catch((err) => next(fillErrorObject(500, 'Server error', [err])));
-}
-
-/**
- * Delete the team member from the database on /team/:teamId/member/:member_id.
- * @param {*} req request object, containing team id in the url
- * @param {*} res response object, the relevant message returned
- * @returns 200: the team member was deleted
- * @returns 404: team is not found
- * @returns 400: team id is not in a valid hexadecimal format
- */
-function deleteTeamMember(req, res, next) {
-  const { foundTeam } = req;
-  const { memberId } = req.params;
-  foundTeam.teamMembers.pull({ _id: memberId });
-  foundTeam
-    .save()
-    .then(() => res.status(200).json(foundTeam.teamMembers))
-    .catch((err) => next(fillErrorObject(500, 'Server error', [err])));
-}
-
-/**
- * Update the team member from the database on /team/:teamId/member.
- * @param {*} req request object, containing team id in the url
- * @param {*} res response object, the updated team member document
- * @returns 200: the team member was updated
- * @returns 404: team is not found
- * @returns 400: team id is not in a valid hexadecimal format
- */
-function updateTeamMember(req, res, next) {
-  const updatedTeamMember = req.body;
-  Team.updateOne(
-    { 'teamMembers._id': updatedTeamMember._id },
-    {
-      $set: {
-        'teamMembers.$': updatedTeamMember,
-      },
-    },
-  )
-    .then(() => res.status(200).json(updatedTeamMember))
-    .catch((err) => next(fillErrorObject(500, 'Server error', [err])));
 }
 
 /**
@@ -290,38 +351,16 @@ async function deployToGHPages(req, res, next) {
   }
 }
 
-/**
- * Update the team from the database on /team/:teamId
- * @param {} req request object, containing team id in the url
- * @param {*} res response object, the updated team document
- * @returns 200: team updated
- * @returns 404: team is not found
- * @returns 400: team id is not in a valid hexadecimal format
- */
-async function updateTeam(req, res, next) {
-  const { teamId: _id } = req.params;
-  const team = req.body;
-
-  try {
-    const updatedTeam = await Team.findByIdAndUpdate(_id, team, {
-      new: true,
-      runValidators: true,
-    });
-    return res.status(200).json(updatedTeam);
-  } catch (err) {
-    return next(fillErrorObject(500, 'Server error', [err]));
-  }
-}
-
 module.exports = {
-  storeHandle,
-  getTeam,
   createTeam,
+  getTeam,
+  updateTeam,
+  deleteTeam,
   createTeamMember,
   readTeamMembersByTeam,
-  deleteTeamMember,
   updateTeamMember,
-  updateTeam,
+  deleteTeamMember,
+  storeHandle,
   getGHAccessToken,
   deployToGHPages,
 };

--- a/api/src/middleware/team.js
+++ b/api/src/middleware/team.js
@@ -6,21 +6,29 @@ const { body, validationResult } = require('express-validator');
 const Team = require('../models/team.model');
 const { fillErrorObject } = require('./error');
 
+/**
+ * Middleware that validates a team id supplied in the request's parameters.
+ * Once validated, the team is attached to the request object for use by
+ * the next middleware.
+ *
+ * @param req request object
+ * @param res response object
+ * @param next handler to the next middleware
+ */
 async function validateTeamId(req, res, next) {
   const { teamId } = req.params;
-  const foundTeam = await Team.findById(teamId)
-    .select('_id teamName orgName email teamMembers');
+  const foundTeam = await Team.findById(teamId);
 
-  if (foundTeam == null) {
-    next(
-      fillErrorObject(404, 'Validation error', [
-        'No team found with the given id',
-      ]),
+  if (!foundTeam) {
+    return next(
+      fillErrorObject(404,
+        'Validation error. No team found with the given id.'),
     );
   }
 
-  req.foundTeam = foundTeam; // todo: does this need to be set inside middleware?
-  next();
+  // Since we've already queried the Team, attach it to the request for reuse.
+  req.foundTeam = foundTeam;
+  return next();
 }
 
 const validateTwitterHandle = [

--- a/api/src/models/team.model.js
+++ b/api/src/models/team.model.js
@@ -1,13 +1,15 @@
 /**
  * This module exports a "Team" mongoose Schema, which represents a researcher team.
  * Post middleware has been implemented to trigger the creation of associated
- * documents upon team registration.
+ * documents upon team registration, and vice-versa for deletion.
  */
 const mongoose = require('mongoose');
 const logger = require('winston');
 
 const Website = require('./website.model');
 const Homepage = require('./homepage.model');
+const Publication = require('./publication.model');
+const Achievement = require('./achievement.model');
 
 const teamSchema = new mongoose.Schema(
   {
@@ -82,6 +84,20 @@ teamSchema.post('save', async (doc) => {
     await Homepage.create({ teamId: doc._id });
   } catch (err) {
     logger.error('Failed to create associated documents on team creation.');
+  }
+});
+
+// Post middleware/trigger to delete dependent documents upon team deletion.
+teamSchema.post('remove', async (doc) => {
+  try {
+    await Website.deleteMany({ teamId: doc._id });
+    await Homepage.deleteMany({ teamId: doc._id });
+    await Publication.deleteMany({ teamId: doc._id });
+    await Achievement.deleteMany({ teamId: doc._id });
+
+    logger.info(`Team ${doc.teamName} & associated documents have been deleted.`);
+  } catch (err) {
+    logger.error('Failed to delete associated documents on team deletion.');
   }
 });
 

--- a/api/src/routes/team.js
+++ b/api/src/routes/team.js
@@ -27,8 +27,7 @@ teamRouter.patch(
 teamRouter.delete('/:teamId',
   mongooseMiddleware.validateTeamObjectId,
   teamMiddleware.validateTeamId,
-  teamController.deleteTeam,
-);
+  teamController.deleteTeam);
 
 teamRouter.post(
   '/:teamId/member',

--- a/api/src/routes/team.js
+++ b/api/src/routes/team.js
@@ -8,18 +8,26 @@ const teamMiddleware = require('../middleware/team');
 const mongooseMiddleware = require('../middleware/mongoose');
 const authMiddleware = require('../middleware/auth');
 
-teamRouter.patch(
-  '/:teamId/twitter-handle',
-  authMiddleware.cookieJwtAuth,
-  teamMiddleware.validateTeamId,
-  teamMiddleware.validateTwitterHandle,
-  teamController.storeHandle,
-);
+teamRouter.post('/', teamController.createTeam);
 
 teamRouter.get(
   '/',
   authMiddleware.cookieJwtAuth,
   teamController.getTeam,
+);
+
+teamRouter.patch(
+  '/:teamId',
+  authMiddleware.cookieJwtAuth,
+  mongooseMiddleware.validateTeamObjectId,
+  teamMiddleware.validateTeamId,
+  teamController.updateTeam,
+);
+
+teamRouter.delete('/:teamId',
+  mongooseMiddleware.validateTeamObjectId,
+  teamMiddleware.validateTeamId,
+  teamController.deleteTeam,
 );
 
 teamRouter.post(
@@ -38,6 +46,14 @@ teamRouter.get(
   teamController.readTeamMembersByTeam,
 );
 
+teamRouter.patch(
+  '/:teamId/member',
+  authMiddleware.cookieJwtAuth,
+  mongooseMiddleware.validateTeamObjectId,
+  teamMiddleware.validateTeamId,
+  teamController.updateTeamMember,
+);
+
 teamRouter.delete(
   '/:teamId/member/:memberId',
   authMiddleware.cookieJwtAuth,
@@ -47,11 +63,11 @@ teamRouter.delete(
 );
 
 teamRouter.patch(
-  '/:teamId/member',
+  '/:teamId/twitter-handle',
   authMiddleware.cookieJwtAuth,
-  mongooseMiddleware.validateTeamObjectId,
   teamMiddleware.validateTeamId,
-  teamController.updateTeamMember,
+  teamMiddleware.validateTwitterHandle,
+  teamController.storeHandle,
 );
 
 teamRouter.get(
@@ -62,16 +78,6 @@ teamRouter.get(
 teamRouter.post(
   '/:teamId/deploy',
   teamController.deployToGHPages,
-);
-
-teamRouter.post('/', teamController.createTeam);
-
-teamRouter.patch(
-  '/:teamId',
-  authMiddleware.cookieJwtAuth,
-  mongooseMiddleware.validateTeamObjectId,
-  teamMiddleware.validateTeamId,
-  teamController.updateTeam,
 );
 
 module.exports = teamRouter;


### PR DESCRIPTION
# Description 

We have middleware for triggering dependent document creation for team registrations. This PR implements a dependent document deletion middleware/hook/trigger to delete associated documents when a team has been deleted.

This PR is a result of comments left in https://github.com/Researchify/Researchify/pull/198.

Note: I've also changed up the positioning of the controller and routes to follow CRUD, so we define create endpoints first, followed by read, update, and then delete (the additions are few, but the diff count is bloated because of this) to make it easier to follow. The only additions are the `deleteTeam()` controller + route, and changes in the `Team` model.



# Type of change 
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation 


# Problem
There is no way to delete a team in the backend.


# Solution description
Implement a delete method for the backend, as well as a post hook that will delete any associated documents.


# Tests 
All unit tests pass? Y

Builds successfully? Y


Attach screenshot of the expected result (e.g. UI of the website/ postman api call result/ database changes)
![Screenshot from 2021-10-04 00-07-53](https://user-images.githubusercontent.com/38117036/135801008-5905a02f-dcf6-45cd-ab29-619126a78aa4.png)

Returns `204` (no content)


Provide steps in detail for reviewers to reproduce the expected result of the code changes.
Please manually verify that the dependent documents have been deleted in the database.

# Risk
Low, additive.
