### PR TITLE
Migrate Docker Images over to new Researchify Docker Hub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,28 +67,28 @@ jobs:
           context: ./api
           file: ./api/Dockerfile
           push: true
-          tags: ak1738/researchify-api:latest
+          tags: researchify/api:latest
       - name: Push Client Image to Docker Hub
         uses: docker/build-push-action@v2
         with:
           context: ./client
           file: ./client/Dockerfile
           push: true
-          tags: ak1738/researchify-client:latest
+          tags: researchify/client:latest
       - name: Push NGINX Image to Docker Hub
         uses: docker/build-push-action@v2
         with:
           context: ./nginx
           file: ./nginx/Dockerfile
           push: true
-          tags: ak1738/researchify-nginx:latest
+          tags: researchify/nginx:latest
       - name: Push Scholly Image to Docker Hub
         uses: docker/build-push-action@v2
         with:
           context: ./scholly
           file: ./scholly/Dockerfile
           push: true
-          tags: ak1738/researchify-scholly:latest
+          tags: researchify/scholly:latest
   deploy:
     name: Deploy to AWS Elastic Beanstalk
     needs:

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -3,14 +3,14 @@
   "containerDefinitions": [
     {
       "name": "client",
-      "image": "ak1738/researchify-client",
+      "image": "researchify/client",
       "hostname": "client",
       "essential": false,
       "memory": 64
     },
     {
       "name": "api",
-      "image": "ak1738/researchify-api",
+      "image": "researchify/api",
       "hostname": "api",
       "essential": false,
       "memory": 256,
@@ -20,14 +20,14 @@
     },
     {
       "name": "scholly",
-      "image": "ak1738/researchify-scholly",
+      "image": "researchify/scholly",
       "hostname": "scholly",
       "essential": false,
       "memory": 512
     },
     {
       "name": "nginx",
-      "image": "ak1738/researchify-nginx",
+      "image": "researchify/nginx",
       "hostname": "nginx",
       "essential": true,
       "portMappings": [


### PR DESCRIPTION
# Description

Up till this point, all Docker images were being pushed to my Docker Hub repository, which the AWS `Dockerrun` deployment relies on. We've long had the task to migrate images over to a central Researchify account, and this PR implements those changes. I've created an email for Researchify as well as a Docker Hub account for it (check the Admin folder on our Team Drive for login access), which will be used to host all the images.

The changes we're making here is to point the Docker build step in our CI pipeline to push images to the new Researchify account, and correspondingly reference those images in the `Dockerrun` config.


# Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Improvement

# Solution description
See description.