### PR TITLE
Revert "Omit eslint config in Dockerfiles by placing in dockerignore"

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,2 +1,1 @@
 node_modules
-.eslintrc.json

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,2 +1,1 @@
 node_modules
-.eslintrc.json

--- a/scholly/.dockerignore
+++ b/scholly/.dockerignore
@@ -1,2 +1,1 @@
 */node_modules
-*/.eslintrc.json


### PR DESCRIPTION
Reverts Researchify/Researchify#244

We initially merged that PR so that we could avoid running ESLint checks (that depended on the AirBnB eslint configuration as a **dev** dependency) when trying to build the scholly base app in **prod**.

In prod, dev dependencies weren't being installed (since we set `NODE_ENV=production` in the image definition) and so AirBnB's ESLint configuration was not pulled into the container. We learned that `react-scripts` needs eslint checks to pass prior to building (i.e. it runs eslint before building) (see https://docs.google.com/document/d/1DHOXFdebFjveb2h0RKIk91itDx-7bSchum358dwdHp8/edit#). So as a stopgap we decided to omit ESLint entirely from prod containers. But this fix isn't ideal because: it **no longer runs ESLint checks in our CI pipeline when publishing images to DockerHub**.

This PR reverts those changes, so that we can implement a more robust solution to the ESLint building failures in prod.